### PR TITLE
Don't ignore `*.import` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .directory
 
 # Godot 3 import folder
-*.import
 .import
 
 # Godot 3 addons


### PR DESCRIPTION
These contain important metadata that should be checked into version control, such as whether an image should be imported with filtering enabled.